### PR TITLE
Fix local music tag and add album playlists

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/LibraryFilter.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/LibraryFilter.kt
@@ -6,5 +6,6 @@ enum class LibraryFilter {
     ALBUMS,
     PLAYLISTS,
     LOCAL_MUSIC,
+    LOCAL_MUSIC_ALBUMS,
     LIBRARY,
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/LocalMusicAlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/LocalMusicAlbumScreen.kt
@@ -134,7 +134,11 @@ fun LocalMusicAlbumScreen(
                             )
 
                             Text(
-                                text = info.artist,
+                                text = if (info.isCompilation && info.uniqueArtists.size > 1) {
+                                    "${info.artist} (${info.uniqueArtists.size} artists)"
+                                } else {
+                                    info.artist
+                                },
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Normal,
                                 color = MaterialTheme.colorScheme.onBackground

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/LocalMusicAlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/LocalMusicAlbumScreen.kt
@@ -1,0 +1,361 @@
+package com.metrolist.music.ui.screens
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.navigation.NavController
+import coil3.compose.AsyncImage
+import com.metrolist.music.LocalPlayerAwareWindowInsets
+import com.metrolist.music.LocalPlayerConnection
+import com.metrolist.music.R
+import com.metrolist.music.constants.AlbumThumbnailSize
+import com.metrolist.music.constants.ThumbnailCornerRadius
+import com.metrolist.music.extensions.toMediaItem
+import com.metrolist.music.extensions.togglePlayPause
+import com.metrolist.music.playback.queues.ListQueue
+import com.metrolist.music.ui.component.AutoResizeText
+import com.metrolist.music.ui.component.FontSizeRange
+import com.metrolist.music.ui.component.IconButton
+import com.metrolist.music.ui.component.LocalMenuState
+import com.metrolist.music.ui.component.SongListItem
+import com.metrolist.music.ui.menu.SelectionSongMenu
+import com.metrolist.music.ui.menu.SongMenu
+import com.metrolist.music.ui.utils.ItemWrapper
+import com.metrolist.music.ui.utils.backToMain
+import com.metrolist.music.viewmodels.LocalMusicAlbumViewModel
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun LocalMusicAlbumScreen(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+    viewModel: LocalMusicAlbumViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val menuState = LocalMenuState.current
+    val haptic = LocalHapticFeedback.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+
+    val isPlaying by playerConnection.isPlaying.collectAsState()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
+
+    val albumInfo by viewModel.albumInfo.collectAsState()
+    val albumSongs by viewModel.albumSongs.collectAsState()
+
+    val wrappedSongs = remember(albumSongs) {
+        albumSongs.map { song -> ItemWrapper(song.toSong()) }.toMutableStateList()
+    }
+    
+    var selection by remember {
+        mutableStateOf(false)
+    }
+
+    if (selection) {
+        BackHandler {
+            selection = false
+        }
+    }
+
+    LazyColumn(
+        contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+    ) {
+        item {
+            albumInfo?.let { info ->
+                Column(
+                    modifier = Modifier.padding(12.dp),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        AsyncImage(
+                            model = info.albumArtUri,
+                            contentDescription = null,
+                            placeholder = painterResource(R.drawable.album),
+                            modifier = Modifier
+                                .size(AlbumThumbnailSize)
+                                .clip(RoundedCornerShape(ThumbnailCornerRadius)),
+                        )
+
+                        Spacer(Modifier.width(16.dp))
+
+                        Column(
+                            verticalArrangement = Arrangement.Center,
+                        ) {
+                            AutoResizeText(
+                                text = info.name,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                                fontSizeRange = FontSizeRange(16.sp, 22.sp),
+                            )
+
+                            Text(
+                                text = info.artist,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Normal,
+                                color = MaterialTheme.colorScheme.onBackground
+                            )
+
+                            if (info.year > 0) {
+                                Text(
+                                    text = info.year.toString(),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.Normal,
+                                )
+                            }
+
+                            Text(
+                                text = pluralStringResource(
+                                    R.plurals.n_song,
+                                    info.songCount,
+                                    info.songCount
+                                ),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.height(12.dp))
+
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Button(
+                            onClick = {
+                                playerConnection.playQueue(
+                                    ListQueue(
+                                        title = info.name,
+                                        items = albumSongs.map { it.toSong().toMediaItem() }
+                                    )
+                                )
+                            },
+                            contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.play),
+                                contentDescription = null,
+                                modifier = Modifier.size(ButtonDefaults.IconSize),
+                            )
+                            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                            Text(
+                                text = stringResource(R.string.play),
+                            )
+                        }
+
+                        OutlinedButton(
+                            onClick = {
+                                playerConnection.playQueue(
+                                    ListQueue(
+                                        title = info.name,
+                                        items = albumSongs.shuffled().map { it.toSong().toMediaItem() }
+                                    )
+                                )
+                            },
+                            contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.shuffle),
+                                contentDescription = null,
+                                modifier = Modifier.size(ButtonDefaults.IconSize),
+                            )
+                            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                            Text(stringResource(R.string.shuffle))
+                        }
+                    }
+                }
+            }
+        }
+
+        if (wrappedSongs.isNotEmpty()) {
+            itemsIndexed(
+                items = wrappedSongs,
+                key = { _, song -> song.item.id },
+            ) { index, songWrapper ->
+                SongListItem(
+                    song = songWrapper.item,
+                    albumIndex = index + 1,
+                    isActive = songWrapper.item.id == mediaMetadata?.id,
+                    isPlaying = isPlaying,
+                    showInLibraryIcon = true,
+                    trailingContent = {
+                        IconButton(
+                            onClick = {
+                                menuState.show {
+                                    SongMenu(
+                                        originalSong = songWrapper.item,
+                                        navController = navController,
+                                        onDismiss = menuState::dismiss,
+                                    )
+                                }
+                            },
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.more_vert),
+                                contentDescription = null,
+                            )
+                        }
+                    },
+                    isSelected = songWrapper.isSelected && selection,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .combinedClickable(
+                            onClick = {
+                                if (!selection) {
+                                    if (songWrapper.item.id == mediaMetadata?.id) {
+                                        playerConnection.player.togglePlayPause()
+                                    } else {
+                                        playerConnection.playQueue(
+                                            ListQueue(
+                                                title = albumInfo?.name ?: "",
+                                                items = albumSongs.map { it.toSong().toMediaItem() },
+                                                startIndex = index
+                                            )
+                                        )
+                                    }
+                                } else {
+                                    songWrapper.isSelected = !songWrapper.isSelected
+                                }
+                            },
+                            onLongClick = {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                if (!selection) {
+                                    selection = true
+                                }
+                                wrappedSongs.forEach {
+                                    it.isSelected = false
+                                } // Clear previous selections
+                                songWrapper.isSelected = true // Select the current item
+                            },
+                        ),
+                )
+            }
+        }
+    }
+
+    TopAppBar(
+        title = {
+            if (selection) {
+                val count = wrappedSongs.count { it.isSelected }
+                Text(
+                    text = pluralStringResource(R.plurals.n_song, count, count),
+                    style = MaterialTheme.typography.titleLarge
+                )
+            } else {
+                Text(
+                    text = albumInfo?.name.orEmpty(),
+                    style = MaterialTheme.typography.titleLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        },
+        navigationIcon = {
+            IconButton(
+                onClick = {
+                    if (selection) {
+                        selection = false
+                    } else {
+                        navController.navigateUp()
+                    }
+                },
+                onLongClick = {
+                    if (!selection) {
+                        navController.backToMain()
+                    }
+                }
+            ) {
+                Icon(
+                    painter = painterResource(
+                        if (selection) R.drawable.close else R.drawable.arrow_back
+                    ),
+                    contentDescription = null
+                )
+            }
+        },
+        actions = {
+            if (selection) {
+                val count = wrappedSongs.count { it.isSelected }
+                IconButton(
+                    onClick = {
+                        if (count == wrappedSongs.size) {
+                            wrappedSongs.forEach { it.isSelected = false }
+                        } else {
+                            wrappedSongs.forEach { it.isSelected = true }
+                        }
+                    },
+                ) {
+                    Icon(
+                        painter = painterResource(
+                            if (count == wrappedSongs.size) R.drawable.deselect else R.drawable.select_all
+                        ),
+                        contentDescription = null
+                    )
+                }
+
+                IconButton(
+                    onClick = {
+                        menuState.show {
+                            SelectionSongMenu(
+                                songSelection = wrappedSongs.filter { it.isSelected }
+                                    .map { it.item },
+                                onDismiss = menuState::dismiss,
+                                clearAction = { selection = false }
+                            )
+                        }
+                    },
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.more_vert),
+                        contentDescription = null
+                    )
+                }
+            }
+        },
+        scrollBehavior = scrollBehavior
+    )
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
@@ -52,6 +52,7 @@ import com.metrolist.music.ui.screens.library.LibraryScreen
 import com.metrolist.music.ui.screens.playlist.AutoPlaylistScreen
 import com.metrolist.music.ui.screens.playlist.LocalPlaylistScreen
 import com.metrolist.music.ui.screens.playlist.LocalMusicPlaylistScreen
+import com.metrolist.music.ui.screens.LocalMusicAlbumScreen
 import com.metrolist.music.ui.screens.playlist.OnlinePlaylistScreen
 import com.metrolist.music.ui.screens.playlist.TopPlaylistScreen
 import com.metrolist.music.ui.screens.playlist.CachePlaylistScreen
@@ -270,6 +271,19 @@ fun NavGraphBuilder.navigationBuilder(
         route = "local_music_playlist"
     ) {
         LocalMusicPlaylistScreen(navController, scrollBehavior)
+    }
+    composable(
+        route = "local_album/{albumName}/{artistName}",
+        arguments = listOf(
+            navArgument("albumName") {
+                type = NavType.StringType
+            },
+            navArgument("artistName") {
+                type = NavType.StringType
+            }
+        )
+    ) {
+        LocalMusicAlbumScreen(navController, scrollBehavior)
     }
     composable(
         route = "youtube_browse/{browseId}?params={params}",

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryScreen.kt
@@ -16,6 +16,7 @@ import com.metrolist.music.constants.ChipSortTypeKey
 import com.metrolist.music.constants.LibraryFilter
 import com.metrolist.music.ui.component.ChipsRow
 import com.metrolist.music.ui.screens.library.LocalMusicScreen
+import com.metrolist.music.ui.screens.library.LocalMusicAlbumsScreen
 import com.metrolist.music.utils.rememberEnumPreference
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,6 +33,7 @@ fun LibraryScreen(navController: NavController) {
                 LibraryFilter.ALBUMS to stringResource(R.string.filter_albums),
                 LibraryFilter.PLAYLISTS to stringResource(R.string.filter_playlists),
                 LibraryFilter.LOCAL_MUSIC to stringResource(R.string.filter_local_music),
+                LibraryFilter.LOCAL_MUSIC_ALBUMS to stringResource(R.string.filter_local_music_albums),
             ),
             currentValue = filterType,
             onValueUpdate = {
@@ -61,7 +63,14 @@ fun LibraryScreen(navController: NavController) {
 
             LibraryFilter.LOCAL_MUSIC -> LocalMusicScreen(
                 navController,
-                filterContent
+                filterContent,
+                onExitLocalMusic = { filterType = LibraryFilter.LIBRARY }
+            )
+
+            LibraryFilter.LOCAL_MUSIC_ALBUMS -> LocalMusicAlbumsScreen(
+                navController,
+                filterContent,
+                onExitLocalAlbums = { filterType = LibraryFilter.LIBRARY }
             )
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicAlbumsScreen.kt
@@ -1,0 +1,251 @@
+package com.metrolist.music.ui.screens.library
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.metrolist.music.LocalPlayerAwareWindowInsets
+import com.metrolist.music.LocalPlayerConnection
+import com.metrolist.music.R
+import com.metrolist.music.constants.CONTENT_TYPE_HEADER
+import com.metrolist.music.extensions.toMediaItem
+import com.metrolist.music.playback.queues.ListQueue
+import com.metrolist.music.ui.component.EmptyPlaceholder
+import com.metrolist.music.viewmodels.LocalMusicViewModel
+import coil3.compose.AsyncImage
+
+data class LocalMusicAlbum(
+    val name: String,
+    val artist: String,
+    val songs: List<com.metrolist.music.db.entities.LocalMusicEntity>,
+    val albumArtUri: String? = null
+) {
+    val songCount: Int get() = songs.size
+    val totalDuration: Long get() = songs.sumOf { it.duration }
+    val year: Int get() = songs.maxOfOrNull { it.year } ?: 0
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun LocalMusicAlbumsScreen(
+    navController: NavController,
+    filterContent: @Composable () -> Unit,
+    onExitLocalAlbums: () -> Unit = {},
+    viewModel: LocalMusicViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+
+    val allLocalMusic by viewModel.allLocalMusic.collectAsState()
+
+    // Group local music by album
+    val localAlbums by remember {
+        derivedStateOf {
+            allLocalMusic
+                .filter { it.album.isNotBlank() }
+                .groupBy { it.album to it.artist }
+                .map { (albumArtist, songs) ->
+                    LocalMusicAlbum(
+                        name = albumArtist.first,
+                        artist = albumArtist.second,
+                        songs = songs.sortedBy { it.track },
+                        albumArtUri = songs.firstOrNull()?.albumArtUri
+                    )
+                }
+                .sortedBy { it.name }
+        }
+    }
+
+    val lazyListState = rememberLazyListState()
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        LazyColumn(
+            state = lazyListState,
+            contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+        ) {
+            item(
+                key = "filter",
+                contentType = CONTENT_TYPE_HEADER,
+            ) {
+                Row {
+                    Spacer(Modifier.width(12.dp))
+                    FilterChip(
+                        label = { Text(stringResource(R.string.filter_local_music_albums)) },
+                        selected = true,
+                        colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
+                        onClick = { onExitLocalAlbums() },
+                        shape = RoundedCornerShape(16.dp),
+                        leadingIcon = {
+                            Icon(
+                                painter = painterResource(R.drawable.close),
+                                contentDescription = stringResource(R.string.close)
+                            )
+                        },
+                    )
+                    Spacer(Modifier.weight(1f))
+                }
+            }
+
+            item(
+                key = "header",
+                contentType = CONTENT_TYPE_HEADER,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.filter_local_music_albums),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+
+                    Spacer(Modifier.weight(1f))
+
+                    Text(
+                        text = pluralStringResource(
+                            R.plurals.n_album,
+                            localAlbums.size,
+                            localAlbums.size
+                        ),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.secondary,
+                    )
+                }
+            }
+
+            if (localAlbums.isEmpty()) {
+                item {
+                    EmptyPlaceholder(
+                        icon = R.drawable.album,
+                        text = stringResource(R.string.no_local_music_found),
+                        modifier = Modifier.animateItem()
+                    )
+                }
+            } else {
+                items(
+                    items = localAlbums,
+                    key = { "${it.name}_${it.artist}" }
+                ) { album ->
+                    LocalMusicAlbumItem(
+                        album = album,
+                        onClick = {
+                            // Create a playlist from the album songs and play it
+                            playerConnection.playQueue(
+                                ListQueue(
+                                    title = album.name,
+                                    items = album.songs.map { it.toSong().toMediaItem() }
+                                )
+                            )
+                        },
+                        modifier = Modifier.animateItem()
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun LocalMusicAlbumItem(
+    album: LocalMusicAlbum,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable { onClick() },
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsyncImage(
+                model = album.albumArtUri,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(RoundedCornerShape(8.dp)),
+                placeholder = R.drawable.album
+            )
+            
+            Spacer(Modifier.width(16.dp))
+            
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = album.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                
+                Text(
+                    text = album.artist,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                
+                Text(
+                    text = pluralStringResource(
+                        R.plurals.n_song,
+                        album.songCount,
+                        album.songCount
+                    ) + if (album.year > 0) " • ${album.year}" else "",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicAlbumsScreen.kt
@@ -212,7 +212,7 @@ fun LocalMusicAlbumItem(
                 modifier = Modifier
                     .size(56.dp)
                     .clip(RoundedCornerShape(8.dp)),
-                placeholder = R.drawable.album
+                placeholder = painterResource(R.drawable.album)
             )
             
             Spacer(Modifier.width(16.dp))

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicAlbumsScreen.kt
@@ -49,6 +49,8 @@ import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.ui.component.EmptyPlaceholder
 import com.metrolist.music.viewmodels.LocalMusicViewModel
 import coil3.compose.AsyncImage
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 data class LocalMusicAlbum(
     val name: String,
@@ -168,13 +170,10 @@ fun LocalMusicAlbumsScreen(
                     LocalMusicAlbumItem(
                         album = album,
                         onClick = {
-                            // Create a playlist from the album songs and play it
-                            playerConnection.playQueue(
-                                ListQueue(
-                                    title = album.name,
-                                    items = album.songs.map { it.toSong().toMediaItem() }
-                                )
-                            )
+                            // Navigate to the local music album page with URL encoding
+                            val encodedAlbumName = URLEncoder.encode(album.name, StandardCharsets.UTF_8.toString())
+                            val encodedArtistName = URLEncoder.encode(album.artist, StandardCharsets.UTF_8.toString())
+                            navController.navigate("local_album/$encodedAlbumName/$encodedArtistName")
                         },
                         modifier = Modifier.animateItem()
                     )

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicAlbumsScreen.kt
@@ -46,21 +46,61 @@ import com.metrolist.music.R
 import com.metrolist.music.constants.CONTENT_TYPE_HEADER
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.playback.queues.ListQueue
+import com.metrolist.music.ui.component.ChipsRow
 import com.metrolist.music.ui.component.EmptyPlaceholder
+import com.metrolist.music.ui.component.SortHeader
 import com.metrolist.music.viewmodels.LocalMusicViewModel
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.metrolist.music.utils.rememberEnumPreference
+import com.metrolist.music.utils.rememberPreference
 import coil3.compose.AsyncImage
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+
+enum class LocalAlbumSortType {
+    NAME,
+    ARTIST,
+    YEAR,
+    SONG_COUNT
+}
+
+enum class LocalAlbumFilter {
+    ALL,
+    REGULAR_ALBUMS,
+    COMPILATIONS
+}
+
+/**
+ * Normalize album names to handle slight variations
+ * This helps group albums that might have minor differences in naming
+ */
+private fun normalizeAlbumName(albumName: String): String {
+    return albumName.trim()
+        .lowercase()
+        .replace(Regex("\\s+"), " ") // Normalize whitespace
+        .replace(Regex("[()\\[\\]{}]"), "") // Remove brackets/parentheses
+        .replace(Regex("[-_]"), " ") // Convert dashes/underscores to spaces
+        .replace("remaster", "")
+        .replace("remastered", "")
+        .replace("deluxe edition", "")
+        .replace("deluxe", "")
+        .replace("special edition", "")
+        .replace("expanded edition", "")
+        .trim()
+}
 
 data class LocalMusicAlbum(
     val name: String,
     val artist: String,
     val songs: List<com.metrolist.music.db.entities.LocalMusicEntity>,
-    val albumArtUri: String? = null
+    val albumArtUri: String? = null,
+    val isCompilation: Boolean = false
 ) {
     val songCount: Int get() = songs.size
     val totalDuration: Long get() = songs.sumOf { it.duration }
     val year: Int get() = songs.maxOfOrNull { it.year } ?: 0
+    val uniqueArtists: List<String> get() = songs.map { it.artist }.distinct()
+    val displayArtist: String get() = if (isCompilation) "Various Artists" else artist
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -75,22 +115,83 @@ fun LocalMusicAlbumsScreen(
     val playerConnection = LocalPlayerConnection.current ?: return
 
     val allLocalMusic by viewModel.allLocalMusic.collectAsState()
+    
+    // Sorting preferences
+    val (sortType, onSortTypeChange) = rememberEnumPreference(
+        stringPreferencesKey("local_album_sort_type"),
+        LocalAlbumSortType.NAME
+    )
+    val (sortDescending, onSortDescendingChange) = rememberPreference(
+        stringPreferencesKey("local_album_sort_descending"),
+        false
+    )
+    
+    // Filter preferences
+    val (albumFilter, onAlbumFilterChange) = rememberEnumPreference(
+        stringPreferencesKey("local_album_filter"),
+        LocalAlbumFilter.ALL
+    )
 
-    // Group local music by album
-    val localAlbums by remember {
+    // Group local music by album with enhanced discovery
+    val localAlbums by remember(allLocalMusic, sortType, sortDescending, albumFilter) {
         derivedStateOf {
-            allLocalMusic
+            val groupedAlbums = allLocalMusic
                 .filter { it.album.isNotBlank() }
-                .groupBy { it.album to it.artist }
-                .map { (albumArtist, songs) ->
+                .groupBy { normalizeAlbumName(it.album) } // Group by normalized album name
+                .mapNotNull { (normalizedAlbumName, songs) ->
+                    if (songs.isEmpty()) return@mapNotNull null
+                    
+                    val uniqueArtists = songs.map { it.artist.trim() }.distinct().filter { it.isNotBlank() }
+                    val artistCounts = songs.groupBy { it.artist.trim() }.mapValues { it.value.size }
+                    
+                    // Enhanced compilation detection
+                    val isCompilation = when {
+                        uniqueArtists.size >= 4 -> true // 4+ artists is definitely compilation
+                        uniqueArtists.size >= 3 && artistCounts.values.all { it <= 2 } -> true // 3+ artists with few tracks each
+                        songs.any { it.artist.contains("feat.", ignoreCase = true) || 
+                                   it.artist.contains("ft.", ignoreCase = true) } -> false // Featured artists don't make it compilation
+                        else -> false
+                    }
+                    
+                    // Determine the primary artist for the album
+                    val primaryArtist = when {
+                        isCompilation -> "Various Artists"
+                        uniqueArtists.size == 1 -> uniqueArtists.first()
+                        else -> {
+                            // Find the artist with the most tracks in this album
+                            artistCounts.maxByOrNull { it.value }?.key ?: uniqueArtists.first()
+                        }
+                    }
+                    
+                    // Use the original album name (not normalized) for display
+                    val displayAlbumName = songs.first().album.trim()
+                    
                     LocalMusicAlbum(
-                        name = albumArtist.first,
-                        artist = albumArtist.second,
-                        songs = songs.sortedBy { it.track },
-                        albumArtUri = songs.firstOrNull()?.albumArtUri
+                        name = displayAlbumName,
+                        artist = primaryArtist,
+                        songs = songs.sortedBy { it.track.takeIf { it > 0 } ?: Int.MAX_VALUE },
+                        albumArtUri = songs.firstOrNull { !it.albumArtUri.isNullOrBlank() }?.albumArtUri 
+                                    ?: songs.firstOrNull()?.albumArtUri,
+                        isCompilation = isCompilation
                     )
                 }
-                .sortedBy { it.name }
+            
+            // Apply filtering
+            val filteredAlbums = when (albumFilter) {
+                LocalAlbumFilter.ALL -> groupedAlbums
+                LocalAlbumFilter.REGULAR_ALBUMS -> groupedAlbums.filter { !it.isCompilation }
+                LocalAlbumFilter.COMPILATIONS -> groupedAlbums.filter { it.isCompilation }
+            }
+            
+            // Apply sorting
+            val sortedAlbums = when (sortType) {
+                LocalAlbumSortType.NAME -> filteredAlbums.sortedBy { it.name.lowercase() }
+                LocalAlbumSortType.ARTIST -> filteredAlbums.sortedBy { it.displayArtist.lowercase() }
+                LocalAlbumSortType.YEAR -> filteredAlbums.sortedBy { it.year }
+                LocalAlbumSortType.SONG_COUNT -> filteredAlbums.sortedBy { it.songCount }
+            }
+            
+            if (sortDescending) sortedAlbums.reversed() else sortedAlbums
         }
     }
 
@@ -122,7 +223,16 @@ fun LocalMusicAlbumsScreen(
                             )
                         },
                     )
-                    Spacer(Modifier.weight(1f))
+                    ChipsRow(
+                        chips = listOf(
+                            LocalAlbumFilter.ALL to "All",
+                            LocalAlbumFilter.REGULAR_ALBUMS to "Albums",
+                            LocalAlbumFilter.COMPILATIONS to "Compilations"
+                        ),
+                        currentValue = albumFilter,
+                        onValueUpdate = onAlbumFilterChange,
+                        modifier = Modifier.weight(1f),
+                    )
                 }
             }
 
@@ -134,10 +244,19 @@ fun LocalMusicAlbumsScreen(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 ) {
-                    Text(
-                        text = stringResource(R.string.filter_local_music_albums),
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.Bold
+                    SortHeader(
+                        sortType = sortType,
+                        sortDescending = sortDescending,
+                        onSortTypeChange = onSortTypeChange,
+                        onSortDescendingChange = onSortDescendingChange,
+                        sortTypeText = { sortType ->
+                            when (sortType) {
+                                LocalAlbumSortType.NAME -> R.string.sort_by_name
+                                LocalAlbumSortType.ARTIST -> R.string.sort_by_artist
+                                LocalAlbumSortType.YEAR -> R.string.sort_by_year
+                                LocalAlbumSortType.SONG_COUNT -> R.string.sort_by_song_count
+                            }
+                        },
                     )
 
                     Spacer(Modifier.weight(1f))
@@ -228,7 +347,7 @@ fun LocalMusicAlbumItem(
                 )
                 
                 Text(
-                    text = album.artist,
+                    text = album.displayArtist,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
@@ -236,11 +355,13 @@ fun LocalMusicAlbumItem(
                 )
                 
                 Text(
-                    text = pluralStringResource(
-                        R.plurals.n_song,
-                        album.songCount,
-                        album.songCount
-                    ) + if (album.year > 0) " • ${album.year}" else "",
+                    text = buildString {
+                        append(pluralStringResource(R.plurals.n_song, album.songCount, album.songCount))
+                        if (album.year > 0) append(" • ${album.year}")
+                        if (album.isCompilation) {
+                            append(" • ${album.uniqueArtists.size} artists")
+                        }
+                    },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
@@ -78,6 +78,7 @@ enum class LocalMusicFilter {
 fun LocalMusicScreen(
     navController: NavController,
     filterContent: @Composable () -> Unit,
+    onExitLocalMusic: () -> Unit = {},
     viewModel: LocalMusicViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -142,12 +143,12 @@ fun LocalMusicScreen(
                         label = { Text(stringResource(R.string.local_music)) },
                         selected = true,
                         colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
-                        onClick = { /* This is handled by filterContent */ },
+                        onClick = { onExitLocalMusic() },
                         shape = RoundedCornerShape(16.dp),
                         leadingIcon = {
                             Icon(
                                 painter = painterResource(R.drawable.close),
-                                contentDescription = ""
+                                contentDescription = stringResource(R.string.close)
                             )
                         },
                     )

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
@@ -576,7 +576,8 @@ fun AppearanceSettings(
             selectedValue = defaultChip,
             values = listOf(
                 LibraryFilter.LIBRARY, LibraryFilter.PLAYLISTS, LibraryFilter.SONGS,
-                LibraryFilter.ALBUMS, LibraryFilter.ARTISTS, LibraryFilter.LOCAL_MUSIC
+                LibraryFilter.ALBUMS, LibraryFilter.ARTISTS, LibraryFilter.LOCAL_MUSIC,
+                LibraryFilter.LOCAL_MUSIC_ALBUMS
             ),
             valueText = {
                 when (it) {
@@ -585,6 +586,7 @@ fun AppearanceSettings(
                     LibraryFilter.ALBUMS -> stringResource(R.string.albums)
                     LibraryFilter.PLAYLISTS -> stringResource(R.string.playlists)
                     LibraryFilter.LOCAL_MUSIC -> stringResource(R.string.local_music)
+                    LibraryFilter.LOCAL_MUSIC_ALBUMS -> stringResource(R.string.filter_local_music_albums)
                     LibraryFilter.LIBRARY -> stringResource(R.string.filter_library)
                 }
             },

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicAlbumViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicAlbumViewModel.kt
@@ -26,9 +26,16 @@ class LocalMusicAlbumViewModel @Inject constructor(
     val albumSongs: StateFlow<List<LocalMusicEntity>> = 
         localMusicRepository.getAllLocalMusic()
             .map { allMusic ->
-                allMusic.filter { 
-                    it.album == albumName && it.artist == artistName 
-                }.sortedBy { it.track }
+                val filteredSongs = if (artistName == "Various Artists") {
+                    // For compilation albums, get all songs with this album name
+                    allMusic.filter { it.album.trim() == albumName }
+                } else {
+                    // For regular albums, filter by both album and artist
+                    allMusic.filter { 
+                        it.album.trim() == albumName && it.artist.trim() == artistName 
+                    }
+                }
+                filteredSongs.sortedBy { it.track.takeIf { it > 0 } ?: Int.MAX_VALUE }
             }
             .stateIn(
                 scope = viewModelScope,
@@ -39,13 +46,18 @@ class LocalMusicAlbumViewModel @Inject constructor(
     val albumInfo: StateFlow<LocalMusicAlbumInfo?> = 
         albumSongs.map { songs ->
             if (songs.isNotEmpty()) {
+                val uniqueArtists = songs.map { it.artist.trim() }.distinct()
+                val isCompilation = artistName == "Various Artists" || uniqueArtists.size > 2
+                
                 LocalMusicAlbumInfo(
                     name = albumName,
                     artist = artistName,
                     year = songs.maxOfOrNull { it.year } ?: 0,
                     songCount = songs.size,
                     totalDuration = songs.sumOf { it.duration },
-                    albumArtUri = songs.firstOrNull()?.albumArtUri
+                    albumArtUri = songs.firstOrNull()?.albumArtUri,
+                    isCompilation = isCompilation,
+                    uniqueArtists = uniqueArtists
                 )
             } else null
         }.stateIn(
@@ -61,5 +73,7 @@ data class LocalMusicAlbumInfo(
     val year: Int,
     val songCount: Int,
     val totalDuration: Long,
-    val albumArtUri: String?
+    val albumArtUri: String?,
+    val isCompilation: Boolean = false,
+    val uniqueArtists: List<String> = emptyList()
 )

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicAlbumViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicAlbumViewModel.kt
@@ -1,0 +1,65 @@
+package com.metrolist.music.viewmodels
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.metrolist.music.db.LocalMusicRepository
+import com.metrolist.music.db.entities.LocalMusicEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+@HiltViewModel
+class LocalMusicAlbumViewModel @Inject constructor(
+    private val localMusicRepository: LocalMusicRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    
+    private val albumName = URLDecoder.decode(savedStateHandle.get<String>("albumName")!!, StandardCharsets.UTF_8.toString())
+    private val artistName = URLDecoder.decode(savedStateHandle.get<String>("artistName")!!, StandardCharsets.UTF_8.toString())
+    
+    val albumSongs: StateFlow<List<LocalMusicEntity>> = 
+        localMusicRepository.getAllLocalMusic()
+            .map { allMusic ->
+                allMusic.filter { 
+                    it.album == albumName && it.artist == artistName 
+                }.sortedBy { it.track }
+            }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = emptyList()
+            )
+    
+    val albumInfo: StateFlow<LocalMusicAlbumInfo?> = 
+        albumSongs.map { songs ->
+            if (songs.isNotEmpty()) {
+                LocalMusicAlbumInfo(
+                    name = albumName,
+                    artist = artistName,
+                    year = songs.maxOfOrNull { it.year } ?: 0,
+                    songCount = songs.size,
+                    totalDuration = songs.sumOf { it.duration },
+                    albumArtUri = songs.firstOrNull()?.albumArtUri
+                )
+            } else null
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null
+        )
+}
+
+data class LocalMusicAlbumInfo(
+    val name: String,
+    val artist: String,
+    val year: Int,
+    val songCount: Int,
+    val totalDuration: Long,
+    val albumArtUri: String?
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
     <string name="filter_featured_playlists">Featured playlists</string>
     <string name="filter_bookmarked">Bookmarked</string>
     <string name="filter_local_music">Local Music</string>
+    <string name="filter_local_music_albums">Local Albums</string>
     <string name="no_results_found">No results found</string>
 
     <!-- Library -->


### PR DESCRIPTION
Fix local music tag exit functionality and add a "Local Music Albums" filter for improved navigation and organization.

The existing "Local Music" filter chip had an empty `onClick` handler, preventing users from closing the filter and returning to the main library view. This PR rectifies that by adding a proper callback.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb48c2b0-b598-4d33-b379-035f3b936fb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb48c2b0-b598-4d33-b379-035f3b936fb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

